### PR TITLE
removed cloud-provider external

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Infrastructure provider for Kubernetes [Cluster API](https://cluster-api.sigs.k8
 | metal-stack Provider v1alpha3 (v0.1) | ✓                           |
 
 ## Compatibility with Kubernetes versions
-|                                      | Kubernetes 1.20             |
+|                                      | Kubernetes 1.21             |
 | ------------------------------------ | --------------------------- |
 | metal-stack Provider v1alpha3 (v0.1) | ✓                           |
 

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -18,7 +18,6 @@ spec:
     - echo "preKubeadmCommands run"
     - sudo apt-get update && sudo apt-get install -y apt-transport-https curl
     - curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg -o key
-    - echo $(wc key)
     - sudo apt-key add key
     - sudo rm key
     - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
@@ -35,9 +34,6 @@ spec:
       localAPIEndpoint:
         advertiseAddress: "${CONTROL_PLANE_IP}"
         bindPort: 6443
-      nodeRegistration:
-        kubeletExtraArgs:
-          cloud-provider: external
     clusterConfiguration:
       controllerManager:
         extraArgs:
@@ -140,10 +136,6 @@ metadata:
 spec:
   template:
     spec:
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            cloud-provider: external
       preKubeadmCommands:
       - echo "waiting for the network"
       - sleep 150


### PR DESCRIPTION
We had problem with `NoSchedule` taint on worker node. It occurred because we were starting cloud controller manager in Control Plane, although we don't have external cloud controller. More on that [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/)