### PR TITLE
Inject docker hub token into e2e tests.

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install kubebuilder
         run: |
           sudo make kubebuilder
-      
+
       - name: Run tests
         run: |
           make test
@@ -58,6 +58,9 @@ jobs:
         ./scripts/ci-prep.sh
         make e2e-prep
         make e2e-run
+      env:
+        DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   build:
     name: Build docker image

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install kubebuilder
         run: |
           sudo make kubebuilder
-      
+
       - name: Run tests
         run: |
           make test
@@ -58,3 +58,6 @@ jobs:
         ./scripts/ci-prep.sh
         make e2e-prep
         make e2e-run
+      env:
+        DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
This will prevent the CI running into rate limits.